### PR TITLE
don't append .conf when calling apache_site lwrp

### DIFF
--- a/definitions/apache2_reverseproxy.rb
+++ b/definitions/apache2_reverseproxy.rb
@@ -34,7 +34,7 @@ define :apache2_reverseproxy, :port => '*', :proxypass_base => '/', :template =>
   end
 
   site_enabled = params[:enable]
-  apache_site "#{params[:name]}.conf" do
+  apache_site "#{params[:name]}" do
     enable site_enabled
   end
 end


### PR DESCRIPTION
apache_site LWRP already appends site so this results in foo.conf.conf when running `a2ensite`